### PR TITLE
Add OS X support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ If you're having trouble with monotonic clocks, see:
 
 Wishlist
 ========
-*	OS X support (no librt, but mostly the same, I think)
-
 *	Windows support.
 
 *	Solaris support (does it work?).

--- a/monoclock.c
+++ b/monoclock.c
@@ -1,6 +1,10 @@
 #include <Python.h>
 #include <time.h>
 
+#ifdef __MACH__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
 
 static PyObject *
 nano_count(PyObject *self, PyObject *args) {
@@ -12,7 +16,22 @@ nano_count(PyObject *self, PyObject *args) {
 		return NULL;
 	}
 
+#ifdef __MACH__
+	static mach_timebase_info_data_t timebase_info;
+	if (timebase_info.denom == 0) {
+		mach_timebase_info(&timebase_info);
+	}
+	uint64_t ticks = mach_absolute_time();
+	/* Divide first then multiply to avoid overflows */
+	ticks /= timebase_info.denom;
+	ticks *= timebase_info.numer;
+	t.tv_sec = ticks / (1000 * 1000 * 1000);
+	t.tv_nsec = ticks % (1000 * 1000 * 1000);
+	ret = 0;
+#else
 	ret = clock_gettime(CLOCK_MONOTONIC, &t);
+#endif
+
 	if(ret != 0) {
 		PyErr_SetString(PyExc_SystemError,
 			"clock_gettime failed");

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 
+import sys
 from distutils.core import setup
 from distutils.extension import Extension
 
+if sys.platform == 'darwin':
+	monoclock_libraries = []
+else:
+	monoclock_libraries = ['rt']
+
 setup(
 	name='Monoclock',
-	version='11.5.3',
+	version='14.4.16',
 	description="Monotonic clock access for Python",
 	url="https://github.com/ludios/Monoclock",
 	author="Ivan Kozik",
@@ -13,10 +19,11 @@ setup(
 	classifiers=[
 		'Development Status :: 5 - Production/Stable',
 		'Operating System :: POSIX :: Linux',
+		'Operating System :: MacOS :: MacOS X'
 		'Intended Audience :: Developers',
 		'License :: OSI Approved :: MIT License',
 	],
 	ext_modules=[
-		Extension("monoclock", ["monoclock.c"], libraries=['rt']),
+		Extension("monoclock", ["monoclock.c"], libraries=monoclock_libraries),
 	],
 )


### PR DESCRIPTION
Use mach_absolute_time and mach_timebase_info to get a monotonic clock
on OS X.

See https://developer.apple.com/library/mac/qa/qa1398/_index.html for
additional information from Apple on the functions used.
